### PR TITLE
Fix exception on Node 6.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function shouldPreRender (options) {
 
   // do pre-render when:
   var query = url.parse(options.url, true).query;
-  if (query && query.hasOwnProperty('_escaped_fragment_')) {
+  if (query && query['_escaped_fragment_'] !== undefined) {
     return true;
   }
 


### PR DESCRIPTION
Deprecate hasOwnProperty to be compatible with Node 6.x.

Running the koa prerender middleware in the latest version of node crashes the app, as expected in the [breaking change log](https://github.com/nodejs/node/pull/6055). 

This lightning edit allows everything to work smoothly! :)